### PR TITLE
fix: decouple npm publish from goreleaser success

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,6 +33,7 @@ jobs:
 
   publish-npm:
     needs: goreleaser
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
## Summary

- Adds `if: !cancelled()` to the `publish-npm` job so it runs even if goreleaser fails (e.g. Homebrew tap auth issue on v3.1.0)
- The npm publish only depends on the GitHub Release existing (which goreleaser creates before attempting the Homebrew push), so it's safe to run independently