### PR TITLE
fix: use correct NPM_AUTH_TOKEN secret name

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,4 +50,4 @@ jobs:
       working-directory: npm
       run: npm publish --access public
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- The repo secret is named `NPM_AUTH_TOKEN`, not `NPM_TOKEN`. Fixes the npm publish auth failure from v3.1.1.