### PR TITLE
fix: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,9 @@ jobs:
     needs: goreleaser
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -48,6 +51,4 @@ jobs:
       run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
     - name: Publish to npm
       working-directory: npm
-      run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

- Replaces static `NPM_AUTH_TOKEN` secret with OIDC trusted publishing (no more expiring tokens)
- Adds `id-token: write` permission to `publish-npm` job
- Adds `--provenance` flag for supply chain attestation