### PR TITLE
fix: update npm for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,6 +46,8 @@ jobs:
       with:
         node-version: "20"
         registry-url: "https://registry.npmjs.org"
+    - name: Update npm
+      run: npm install -g npm@latest
     - name: Set package version from tag
       working-directory: npm
       run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version


### PR DESCRIPTION
## Summary

- OIDC trusted publishing requires npm >= 11.5.1; Node 20 ships with npm 10.x
- Adds `npm install -g npm@latest` step before publish, matching the working pattern in [courier-web](https://github.com/trycourier/courier-web/blob/main/.github/workflows/release.yml)