### PR TITLE
docs: add README for npm package page

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,37 @@
+# Courier CLI
+
+The official CLI for the [Courier REST API](https://www.courier.com/docs). Manage notifications, templates, users, and more from the command line.
+
+## Installation
+
+```sh
+npm install -g @trycourier/cli
+```
+
+### Other install methods
+
+- **Homebrew**: `brew install trycourier/courier/courier`
+- **Go**: `go install github.com/trycourier/courier-cli/cmd/courier@latest`
+- **Binary**: [GitHub Releases](https://github.com/trycourier/courier-cli/releases)
+
+## Usage
+
+```sh
+export COURIER_API_KEY=your_api_key
+
+courier send message --message.to.email "user@example.com" --message.template "my-template"
+courier messages list
+courier profiles retrieve --user-id "user-123"
+```
+
+For details about specific commands, use `courier --help`.
+
+## How it works
+
+This package downloads the platform-specific Courier CLI binary from [GitHub Releases](https://github.com/trycourier/courier-cli/releases) during `npm install`. No Node.js runtime dependency at execution time.
+
+## Documentation
+
+- [Courier Docs](https://www.courier.com/docs)
+- [CLI Repository](https://github.com/trycourier/courier-cli)
+- [API Reference](https://www.courier.com/docs/reference)


### PR DESCRIPTION
## Summary

- Adds a README to the `npm/` directory so the [npm package page](https://www.npmjs.com/package/@trycourier/cli) shows install instructions and usage examples instead of being blank
- Will be included in the next npm publish automatically