### PR TITLE
fix: add Node shim so npm creates bin symlink on install

### DIFF
--- a/npm/bin/courier.js
+++ b/npm/bin/courier.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const binary = process.platform === "win32" ? "courier.exe" : "courier";
+const binPath = path.join(__dirname, binary);
+
+try {
+  execFileSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+} catch (err) {
+  if (err.status !== undefined) {
+    process.exit(err.status);
+  }
+  console.error(`Failed to run Courier CLI: ${err.message}`);
+  console.error(`Expected binary at: ${binPath}`);
+  console.error(`Try reinstalling: npm install -g @trycourier/cli`);
+  process.exit(1);
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Courier CLI – manage notifications from the command line",
   "bin": {
-    "courier": "./bin/courier"
+    "courier": "./bin/courier.js"
   },
   "scripts": {
     "postinstall": "node install.js"


### PR DESCRIPTION
## Summary

- `npm install -g @trycourier/cli` silently fails to create the `courier` bin symlink because npm links before postinstall runs, and the native binary doesn't exist in the tarball yet (only `bin/.gitkeep`)
- Adds `npm/bin/courier.js`, a Node shim that `execFileSync`s the native binary downloaded by postinstall. Same pattern used by biome and esbuild.
- Changes `package.json` bin from `./bin/courier` to `./bin/courier.js` so npm has a real file to symlink at install time
- Verified with cold-start uninstall/reinstall: symlink created, binary runs, API calls work