### PR TITLE
Improve test suite: remove redundancy, add table-driven tests, fill coverage gaps

### DIFF
--- a/cmd/courier/main_test.go
+++ b/cmd/courier/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trycourier/courier-cli/pkg/cmd"
+	"github.com/urfave/cli/v3"
+)
+
+func TestPrepareForAutocomplete(t *testing.T) {
+	t.Parallel()
+
+	root := &cli.Command{
+		Name: "test",
+		Commands: []*cli.Command{
+			{
+				Name: "child1",
+				Commands: []*cli.Command{
+					{Name: "grandchild1"},
+				},
+			},
+			{Name: "child2"},
+		},
+	}
+
+	assert.False(t, root.SkipFlagParsing)
+	assert.False(t, root.Commands[0].SkipFlagParsing)
+	assert.False(t, root.Commands[0].Commands[0].SkipFlagParsing)
+	assert.False(t, root.Commands[1].SkipFlagParsing)
+
+	prepareForAutocomplete(root)
+
+	assert.True(t, root.SkipFlagParsing, "root should have SkipFlagParsing set")
+	assert.True(t, root.Commands[0].SkipFlagParsing, "child1 should have SkipFlagParsing set")
+	assert.True(t, root.Commands[0].Commands[0].SkipFlagParsing, "grandchild1 should have SkipFlagParsing set")
+	assert.True(t, root.Commands[1].SkipFlagParsing, "child2 should have SkipFlagParsing set")
+}
+
+func TestPrepareForAutocomplete_EmptyCommand(t *testing.T) {
+	t.Parallel()
+
+	root := &cli.Command{Name: "empty"}
+	prepareForAutocomplete(root)
+	assert.True(t, root.SkipFlagParsing)
+}
+
+func TestCommandErrorBuffer(t *testing.T) {
+	t.Parallel()
+
+	// Verify the CommandErrorBuffer exists and is usable
+	cmd.CommandErrorBuffer.Reset()
+	assert.Equal(t, 0, cmd.CommandErrorBuffer.Len())
+
+	cmd.CommandErrorBuffer.WriteString("test error")
+	assert.Equal(t, "test error", cmd.CommandErrorBuffer.String())
+	cmd.CommandErrorBuffer.Reset()
+}
+
+func TestAppCommandIsInitialized(t *testing.T) {
+	t.Parallel()
+
+	app := cmd.Command
+	assert.NotNil(t, app)
+	assert.Equal(t, "courier", app.Name)
+	assert.NotEmpty(t, app.Version)
+	assert.NotEmpty(t, app.Commands)
+}

--- a/internal/autocomplete/autocomplete_test.go
+++ b/internal/autocomplete/autocomplete_test.go
@@ -391,3 +391,58 @@ func TestGetCompletions_AllFlagsWhenNoPrefix(t *testing.T) {
 	// Should show all flag variations
 	assert.GreaterOrEqual(t, len(result.Completions), 6) // -o, --output, -v, --verbose, -f, --format
 }
+
+func TestRebuildColonSeparatedArgs_Empty(t *testing.T) {
+	assert.Equal(t, []string{}, rebuildColonSeparatedArgs([]string{}))
+}
+
+func TestRebuildColonSeparatedArgs_NoColons(t *testing.T) {
+	args := []string{"a", "b", "c"}
+	assert.Equal(t, []string{"a", "b", "c"}, rebuildColonSeparatedArgs(args))
+}
+
+func TestRebuildColonSeparatedArgs_SingleColon(t *testing.T) {
+	args := []string{"a", ":", "b"}
+	assert.Equal(t, []string{"a:b"}, rebuildColonSeparatedArgs(args))
+}
+
+func TestRebuildColonSeparatedArgs_MultipleColons(t *testing.T) {
+	args := []string{"a", ":", "b", ":", "c"}
+	assert.Equal(t, []string{"a:b:c"}, rebuildColonSeparatedArgs(args))
+}
+
+func TestRebuildColonSeparatedArgs_ColonAtEnd(t *testing.T) {
+	args := []string{"a", "b", ":"}
+	result := rebuildColonSeparatedArgs(args)
+	assert.Equal(t, []string{"a", "b:"}, result)
+}
+
+func TestRebuildColonSeparatedArgs_ColonAtStart(t *testing.T) {
+	args := []string{":", "a", "b"}
+	result := rebuildColonSeparatedArgs(args)
+	// A leading colon joins with the next arg
+	assert.Equal(t, []string{":", "a", "b"}, result)
+}
+
+func TestRebuildColonSeparatedArgs_MixedNormalAndColon(t *testing.T) {
+	args := []string{"config", ":", "get", "d"}
+	result := rebuildColonSeparatedArgs(args)
+	assert.Equal(t, []string{"config:get", "d"}, result)
+}
+
+func TestRebuildColonSeparatedArgs_ConsecutiveColons(t *testing.T) {
+	args := []string{"a", ":", ":", "b"}
+	result := rebuildColonSeparatedArgs(args)
+	assert.Equal(t, []string{"a::b"}, result)
+}
+
+func TestRebuildColonSeparatedArgs_SingleElement(t *testing.T) {
+	args := []string{"hello"}
+	assert.Equal(t, []string{"hello"}, rebuildColonSeparatedArgs(args))
+}
+
+func TestRebuildColonSeparatedArgs_ColonOnly(t *testing.T) {
+	args := []string{":"}
+	result := rebuildColonSeparatedArgs(args)
+	assert.Equal(t, []string{":"}, result)
+}

--- a/internal/jsonview/explorer_test.go
+++ b/internal/jsonview/explorer_test.go
@@ -1,0 +1,459 @@
+package jsonview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestNewTextView(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid string", func(t *testing.T) {
+		data := gjson.Parse(`"hello world"`)
+		tv, err := newTextView("root", data)
+		require.NoError(t, err)
+		assert.Equal(t, "root", tv.GetPath())
+		assert.Equal(t, "hello world", tv.GetData().String())
+	})
+
+	t.Run("non-string type returns error", func(t *testing.T) {
+		data := gjson.Parse(`42`)
+		_, err := newTextView("root", data)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid text JSON")
+	})
+
+	t.Run("non-existent returns error", func(t *testing.T) {
+		data := gjson.Parse("")
+		_, err := newTextView("root", data)
+		assert.Error(t, err)
+	})
+}
+
+func TestNewTableView_Object(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"name":"Alice","age":30}`)
+	tv, err := newTableView("", data, false)
+	require.NoError(t, err)
+	assert.Equal(t, "", tv.GetPath())
+	assert.True(t, tv.GetData().IsObject())
+	assert.Len(t, tv.rowData, 2)
+}
+
+func TestNewTableView_Array(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`[1,2,3]`)
+	tv, err := newTableView("items", data, false)
+	require.NoError(t, err)
+	assert.Equal(t, "items", tv.GetPath())
+	assert.True(t, tv.GetData().IsArray())
+	assert.Len(t, tv.rowData, 3)
+}
+
+func TestNewTableView_ArrayOfObjects(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`[{"id":1,"name":"a"},{"id":2,"name":"b"}]`)
+	tv, err := newTableView("", data, false)
+	require.NoError(t, err)
+	assert.Len(t, tv.rowData, 2)
+	assert.Len(t, tv.columns, 2)
+}
+
+func TestNewTableView_EmptyArray(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`[]`)
+	tv, err := newTableView("", data, false)
+	require.NoError(t, err)
+	assert.Len(t, tv.rowData, 0)
+}
+
+func TestNewTableView_EmptyObject(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{}`)
+	tv, err := newTableView("", data, false)
+	require.NoError(t, err)
+	assert.Len(t, tv.rowData, 0)
+}
+
+func TestNewTableView_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`"string value"`)
+	_, err := newTableView("", data, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid table JSON")
+}
+
+func TestNewTableView_NonExistent(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse("")
+	_, err := newTableView("", data, false)
+	assert.Error(t, err)
+}
+
+func TestNewView_DispatchesToCorrectType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string creates TextView", func(t *testing.T) {
+		data := gjson.Parse(`"hello"`)
+		view, err := newView("", data, false)
+		require.NoError(t, err)
+		_, ok := view.(*TextView)
+		assert.True(t, ok, "expected *TextView, got %T", view)
+	})
+
+	t.Run("object creates TableView", func(t *testing.T) {
+		data := gjson.Parse(`{"key":"val"}`)
+		view, err := newView("", data, false)
+		require.NoError(t, err)
+		_, ok := view.(*TableView)
+		assert.True(t, ok, "expected *TableView, got %T", view)
+	})
+
+	t.Run("array creates TableView", func(t *testing.T) {
+		data := gjson.Parse(`[1,2]`)
+		view, err := newView("", data, false)
+		require.NoError(t, err)
+		_, ok := view.(*TableView)
+		assert.True(t, ok, "expected *TableView, got %T", view)
+	})
+}
+
+func TestFormatValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		raw      bool
+		contains string
+	}{
+		{"string normal", `"hello"`, false, "hello"},
+		{"number normal", `42`, false, "42"},
+		{"object normal", `{"a":1}`, false, "{"},
+		{"array normal", `[1,2]`, false, "2 items"},
+		{"string raw", `"hello"`, true, "hello"},
+		{"number raw", `42`, true, "42"},
+		{"object raw", `{"a":1}`, true, `"a":1`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := gjson.Parse(tt.json)
+			output := formatValue(data, tt.raw)
+			assert.Contains(t, output, tt.contains)
+		})
+	}
+}
+
+func TestFormatObject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		contains []string
+	}{
+		{
+			"simple object",
+			`{"name":"Alice","age":30}`,
+			[]string{"name:", "Alice", "age:", "30"},
+		},
+		{
+			"nested object",
+			`{"outer":{"inner":1}}`,
+			[]string{"outer:{…}"},
+		},
+		{
+			"nested array",
+			`{"items":[1,2,3]}`,
+			[]string{"items:[…]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := gjson.Parse(tt.json)
+			output := formatObject(data)
+			for _, s := range tt.contains {
+				assert.Contains(t, output, s)
+			}
+		})
+	}
+}
+
+func TestFormatArray(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{"empty", `[]`, "[]"},
+		{"one item", `[1]`, "[...1 item...]"},
+		{"multiple items", `[1,2,3]`, "[...3 items...]"},
+		{"ten items", `[1,2,3,4,5,6,7,8,9,10]`, "[...10 items...]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := gjson.Parse(tt.json)
+			output := formatArray(data)
+			assert.Equal(t, tt.expected, output)
+		})
+	}
+}
+
+func TestIsArrayOfObjects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		expected bool
+	}{
+		{"all objects", `[{"a":1},{"b":2}]`, true},
+		{"mixed", `[{"a":1},2]`, false},
+		{"all primitives", `[1,2,3]`, false},
+		{"empty", `[]`, false},
+		{"single object", `[{"a":1}]`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			array := gjson.Parse(tt.json).Array()
+			assert.Equal(t, tt.expected, isArrayOfObjects(array))
+		})
+	}
+}
+
+func TestCanNavigateInto(t *testing.T) {
+	t.Parallel()
+
+	viewer := &JSONViewer{}
+
+	tests := []struct {
+		name     string
+		json     string
+		expected bool
+	}{
+		{"non-empty object", `{"key":"val"}`, true},
+		{"empty object", `{}`, false},
+		{"non-empty array", `[1,2,3]`, true},
+		{"empty array", `[]`, false},
+		{"short string", `"hello"`, false},
+		{"number", `42`, false},
+		{"boolean", `true`, false},
+		{"null", `null`, false},
+		{"multiline string", `"line1\nline2\nline3"`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := gjson.Parse(tt.json)
+			assert.Equal(t, tt.expected, viewer.canNavigateInto(data))
+		})
+	}
+}
+
+func TestSum(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, sum([]int{}))
+	assert.Equal(t, 0, sum(nil))
+	assert.Equal(t, 6, sum([]int{1, 2, 3}))
+	assert.Equal(t, -3, sum([]int{-1, -2, 0}))
+	assert.Equal(t, 100, sum([]int{100}))
+}
+
+func TestQuoteString(t *testing.T) {
+	t.Parallel()
+
+	result := quoteString("hello")
+	assert.Contains(t, result, `"hello"`)
+
+	result = quoteString(`say "hi"`)
+	assert.Contains(t, result, `\"hi\"`)
+
+	result = quoteString(`back\slash`)
+	assert.Contains(t, result, `\\`)
+}
+
+func TestJSONViewerBuildTitle(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"a":1}`)
+	view, _ := newView("items[0]", data, false)
+
+	t.Run("with path", func(t *testing.T) {
+		viewer := &JSONViewer{stack: []JSONView{view}, root: "Test"}
+		title := viewer.buildTitle(view)
+		assert.Contains(t, title, "Test")
+		assert.Contains(t, title, "items[0]")
+	})
+
+	t.Run("raw mode", func(t *testing.T) {
+		viewer := &JSONViewer{stack: []JSONView{view}, root: "Test", rawMode: true}
+		title := viewer.buildTitle(view)
+		assert.Contains(t, title, "(JSON)")
+	})
+
+	t.Run("root only", func(t *testing.T) {
+		rootView, _ := newView("", data, false)
+		viewer := &JSONViewer{stack: []JSONView{rootView}, root: "MyRoot"}
+		title := viewer.buildTitle(rootView)
+		assert.Equal(t, "MyRoot", title)
+	})
+}
+
+func TestJSONViewerNavigateBack(t *testing.T) {
+	t.Parallel()
+
+	data1 := gjson.Parse(`{"a":1}`)
+	data2 := gjson.Parse(`{"b":2}`)
+	view1, _ := newView("", data1, false)
+	view2, _ := newView("a", data2, false)
+
+	viewer := &JSONViewer{stack: []JSONView{view1, view2}, root: "Test"}
+	assert.Len(t, viewer.stack, 2)
+
+	viewer.navigateBack()
+	assert.Len(t, viewer.stack, 1)
+
+	// Should not go below 1
+	viewer.navigateBack()
+	assert.Len(t, viewer.stack, 1)
+}
+
+func TestJSONViewerGetStyleForData(t *testing.T) {
+	t.Parallel()
+
+	viewer := &JSONViewer{}
+
+	// These should not panic
+	viewer.getStyleForData(gjson.Parse(`"string"`))
+	viewer.getStyleForData(gjson.Parse(`[1,2]`))
+	viewer.getStyleForData(gjson.Parse(`{"a":1}`))
+	viewer.getStyleForData(gjson.Parse(`42`))
+}
+
+func TestBuildNavigationPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("array path", func(t *testing.T) {
+		data := gjson.Parse(`[{"id":1},{"id":2}]`)
+		tv, _ := newTableView("items", data, false)
+		viewer := &JSONViewer{}
+		path := viewer.buildNavigationPath(tv, 0)
+		assert.Equal(t, "items[0]", path)
+	})
+
+	t.Run("object path", func(t *testing.T) {
+		data := gjson.Parse(`{"name":"Alice","age":30}`)
+		tv, _ := newTableView("user", data, false)
+		viewer := &JSONViewer{}
+		path := viewer.buildNavigationPath(tv, 0)
+		assert.Contains(t, path, "user[")
+	})
+}
+
+func TestGenericIterator(t *testing.T) {
+	t.Parallel()
+
+	items := []string{"a", "b", "c"}
+	it := &sliceIterator[string]{items: items, index: -1}
+	anyIt := genericToAnyIterator[string](it)
+
+	var results []any
+	for anyIt.Next() {
+		results = append(results, anyIt.Current())
+	}
+
+	assert.NoError(t, anyIt.Err())
+	assert.Equal(t, []any{"a", "b", "c"}, results)
+}
+
+func TestGenericIterator_Empty(t *testing.T) {
+	t.Parallel()
+
+	it := &sliceIterator[int]{items: []int{}, index: -1}
+	anyIt := genericToAnyIterator[int](it)
+
+	assert.False(t, anyIt.Next())
+	assert.NoError(t, anyIt.Err())
+}
+
+// sliceIterator is a test helper implementing Iterator[T]
+type sliceIterator[T any] struct {
+	items   []T
+	index   int
+	current T
+}
+
+func (s *sliceIterator[T]) Next() bool {
+	s.index++
+	if s.index >= len(s.items) {
+		return false
+	}
+	s.current = s.items[s.index]
+	return true
+}
+
+func (s *sliceIterator[T]) Current() T {
+	return s.current
+}
+
+func (s *sliceIterator[T]) Err() error {
+	return nil
+}
+
+func TestTableViewResize(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`[{"id":1,"name":"a"},{"id":2,"name":"b"}]`)
+	tv, err := newTableView("", data, false)
+	require.NoError(t, err)
+
+	// Should not panic
+	tv.Resize(100, 50)
+	assert.Equal(t, 100, tv.width)
+	assert.Equal(t, 50, tv.height)
+
+	tv.Resize(40, 20)
+	assert.Equal(t, 40, tv.width)
+	assert.Equal(t, 20, tv.height)
+}
+
+func TestFormatObjectKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		key      string
+		val      gjson.Result
+		contains string
+	}{
+		{"object value", "nested", gjson.Parse(`{"a":1}`), "{…}"},
+		{"array value", "items", gjson.Parse(`[1,2]`), "[…]"},
+		{"short string", "name", gjson.Parse(`"Bob"`), `"Bob"`},
+		{"number", "count", gjson.Parse(`42`), "42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := formatObjectKey(tt.key, tt.val)
+			assert.Contains(t, output, tt.key)
+			assert.Contains(t, output, tt.contains)
+		})
+	}
+}

--- a/internal/jsonview/staticdisplay_test.go
+++ b/internal/jsonview/staticdisplay_test.go
@@ -1,0 +1,98 @@
+package jsonview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func TestFormatJSON_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	result := gjson.Parse("")
+	output := formatJSON(result, 80)
+	assert.Contains(t, output, "Invalid JSON")
+}
+
+func TestFormatResult_AllTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		width    int
+		contains []string
+	}{
+		{"string", `"hello"`, 200, []string{"hello"}},
+		{"empty string", `""`, 200, []string{"(empty)"}},
+		{"integer", `99`, 200, []string{"99"}},
+		{"negative", `-5`, 200, []string{"-5"}},
+		{"float", `1.5`, 200, []string{"1.5"}},
+		{"true", `true`, 200, []string{"yes"}},
+		{"false", `false`, 200, []string{"no"}},
+		{"null", `null`, 200, []string{"null"}},
+		{"object", `{"name":"Alice","age":30}`, 200, []string{"name:", "Alice", "age:", "30"}},
+		{"empty object", `{}`, 200, []string{"(empty)"}},
+		{"array", `["a","b","c"]`, 200, []string{"1.", "a", "2.", "b", "3.", "c"}},
+		{"empty array", `[]`, 200, []string{"(none)"}},
+		{"nested object", `{"user":{"name":"Bob"}}`, 200, []string{"user:", "name:", "Bob"}},
+		{"array of objects", `[{"id":1},{"id":2}]`, 200, []string{"1.", "2.", "id:"}},
+		{"narrow width doesn't panic", `"` + string(make([]byte, 200)) + `"`, 20, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gjson.Parse(tt.json)
+			output := formatResult(result, 0, tt.width)
+			if len(tt.contains) == 0 {
+				assert.NotEmpty(t, output)
+			}
+			for _, s := range tt.contains {
+				assert.Contains(t, output, s)
+			}
+		})
+	}
+}
+
+func TestIsSingleLine(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isSingleLine(gjson.Parse(`"hello"`), 0))
+	assert.True(t, isSingleLine(gjson.Parse(`42`), 0))
+	assert.True(t, isSingleLine(gjson.Parse(`true`), 0))
+	assert.True(t, isSingleLine(gjson.Parse(`null`), 0))
+	assert.False(t, isSingleLine(gjson.Parse(`{"key":"val"}`), 0))
+	assert.False(t, isSingleLine(gjson.Parse(`[1,2,3]`), 0))
+}
+
+func TestGetIndent(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", getIndent(0))
+	assert.Equal(t, "  ", getIndent(1))
+	assert.Equal(t, "    ", getIndent(2))
+	assert.Equal(t, "      ", getIndent(3))
+}
+
+func TestRenderJSON(t *testing.T) {
+	t.Parallel()
+
+	result := gjson.Parse(`{"status":"ok","count":5}`)
+	output := RenderJSON("Test Title", result)
+	assert.Contains(t, output, "Test Title")
+	assert.Contains(t, output, "status:")
+	assert.Contains(t, output, "ok")
+	assert.Contains(t, output, "count:")
+	assert.Contains(t, output, "5")
+}
+
+func TestRenderJSON_Array(t *testing.T) {
+	t.Parallel()
+
+	result := gjson.Parse(`[1,2,3]`)
+	output := RenderJSON("Array Title", result)
+	assert.Contains(t, output, "Array Title")
+	assert.Contains(t, output, "1")
+	assert.Contains(t, output, "2")
+	assert.Contains(t, output, "3")
+}

--- a/internal/mocktest/mocktest.go
+++ b/internal/mocktest/mocktest.go
@@ -60,12 +60,20 @@ func TestRunMockTestWithFlags(t *testing.T, flags ...string) {
 	defer restoreNetwork(origClient, origDefault)
 
 	// Check if mock server is running
-	conn, err := net.DialTimeout("tcp", mockServerURL.Host, 2*time.Second)
-	if err != nil {
-		require.Fail(t, "Mock server is not running on "+mockServerURL.Host+". Please start the mock server before running tests.")
-	} else {
-		conn.Close()
+	host := mockServerURL.Host
+	if !strings.Contains(host, ":") {
+		if mockServerURL.Scheme == "https" {
+			host += ":443"
+		} else {
+			host += ":80"
+		}
 	}
+	conn, err := net.DialTimeout("tcp", host, 2*time.Second)
+	if err != nil {
+		t.Skipf("Mock server is not reachable on %s; skipping (set TEST_API_BASE_URL or start a mock server)", mockServerURL.Host)
+		return
+	}
+	conn.Close()
 
 	// Get the path to the main command
 	_, filename, _, ok := runtime.Caller(0)

--- a/pkg/cmd/audience_test.go
+++ b/pkg/cmd/audience_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAudiencesRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"audiences", "retrieve",
@@ -20,7 +19,6 @@ func TestAudiencesRetrieve(t *testing.T) {
 }
 
 func TestAudiencesUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"audiences", "update",
@@ -48,7 +46,6 @@ func TestAudiencesUpdate(t *testing.T) {
 }
 
 func TestAudiencesList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"audiences", "list",
@@ -58,7 +55,6 @@ func TestAudiencesList(t *testing.T) {
 }
 
 func TestAudiencesDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"audiences", "delete",
@@ -68,7 +64,6 @@ func TestAudiencesDelete(t *testing.T) {
 }
 
 func TestAudiencesListMembers(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"audiences", "list-members",

--- a/pkg/cmd/auditevent_test.go
+++ b/pkg/cmd/auditevent_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAuditEventsRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"audit-events", "retrieve",
@@ -19,7 +18,6 @@ func TestAuditEventsRetrieve(t *testing.T) {
 }
 
 func TestAuditEventsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"audit-events", "list",

--- a/pkg/cmd/auth_test.go
+++ b/pkg/cmd/auth_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAuthIssueToken(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"auth", "issue-token",

--- a/pkg/cmd/automation_test.go
+++ b/pkg/cmd/automation_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAutomationsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"automations", "list",

--- a/pkg/cmd/automationinvoke_test.go
+++ b/pkg/cmd/automationinvoke_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAutomationsInvokeInvokeAdHoc(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"automations:invoke", "invoke-ad-hoc",
@@ -41,7 +40,6 @@ func TestAutomationsInvokeInvokeAdHoc(t *testing.T) {
 }
 
 func TestAutomationsInvokeInvokeByTemplate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"automations:invoke", "invoke-by-template",

--- a/pkg/cmd/brand_test.go
+++ b/pkg/cmd/brand_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestBrandsCreate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"brands", "create",
@@ -38,7 +37,6 @@ func TestBrandsCreate(t *testing.T) {
 }
 
 func TestBrandsRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"brands", "retrieve",
@@ -48,7 +46,6 @@ func TestBrandsRetrieve(t *testing.T) {
 }
 
 func TestBrandsUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"brands", "update",
@@ -76,7 +73,6 @@ func TestBrandsUpdate(t *testing.T) {
 }
 
 func TestBrandsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"brands", "list",
@@ -86,7 +82,6 @@ func TestBrandsList(t *testing.T) {
 }
 
 func TestBrandsDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"brands", "delete",

--- a/pkg/cmd/bulk_test.go
+++ b/pkg/cmd/bulk_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestBulkAddUsers(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"bulk", "add-users",
@@ -36,7 +35,6 @@ func TestBulkAddUsers(t *testing.T) {
 }
 
 func TestBulkCreateJob(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"bulk", "create-job",
@@ -62,7 +60,6 @@ func TestBulkCreateJob(t *testing.T) {
 }
 
 func TestBulkListUsers(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"bulk", "list-users",
@@ -73,7 +70,6 @@ func TestBulkListUsers(t *testing.T) {
 }
 
 func TestBulkRetrieveJob(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"bulk", "retrieve-job",
@@ -83,7 +79,6 @@ func TestBulkRetrieveJob(t *testing.T) {
 }
 
 func TestBulkRunJob(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"bulk", "run-job",

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestCommandStructure(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, Command)
+	assert.Equal(t, "courier", Command.Name)
+	assert.Equal(t, Version, Command.Version)
+}
+
+func TestCommandHasExpectedSubcommands(t *testing.T) {
+	t.Parallel()
+
+	expectedNames := []string{
+		"send",
+		"audiences",
+		"audit-events",
+		"auth",
+		"automations",
+		"automations:invoke",
+		"brands",
+		"bulk",
+		"inbound",
+		"lists",
+		"lists:subscriptions",
+		"messages",
+		"requests",
+		"notifications",
+		"notifications:draft",
+		"notifications:checks",
+		"profiles",
+		"profiles:lists",
+		"tenants",
+		"tenants:preferences:items",
+		"tenants:templates",
+		"tenants:templates:versions",
+		"translations",
+		"users:preferences",
+		"users:tenants",
+		"users:tokens",
+	}
+
+	actualNames := make([]string, 0, len(Command.Commands))
+	for _, cmd := range Command.Commands {
+		if !cmd.Hidden {
+			actualNames = append(actualNames, cmd.Name)
+		}
+	}
+
+	for _, expected := range expectedNames {
+		assert.True(t, slices.Contains(actualNames, expected), "missing subcommand: %s", expected)
+	}
+}
+
+func TestCommandHiddenSubcommands(t *testing.T) {
+	t.Parallel()
+
+	hiddenNames := []string{"@manpages", "__complete", "@completion"}
+
+	for _, name := range hiddenNames {
+		t.Run(name, func(t *testing.T) {
+			var found bool
+			for _, cmd := range Command.Commands {
+				if cmd.Name == name {
+					found = true
+					assert.True(t, cmd.Hidden, "subcommand %s should be hidden", name)
+				}
+			}
+			assert.True(t, found, "hidden subcommand %s not found", name)
+		})
+	}
+}
+
+func TestCommandGlobalFlags(t *testing.T) {
+	t.Parallel()
+
+	flagNames := make([]string, 0)
+	for _, flag := range Command.Flags {
+		flagNames = append(flagNames, flag.Names()...)
+	}
+
+	expectedFlags := []string{"debug", "base-url", "format", "format-error", "transform", "transform-error", "api-key"}
+	for _, expected := range expectedFlags {
+		assert.True(t, slices.Contains(flagNames, expected), "missing global flag: %s", expected)
+	}
+}
+
+func TestCommandFormatValidator(t *testing.T) {
+	t.Parallel()
+
+	// Find the format flag
+	var formatFlag *cli.StringFlag
+	for _, f := range Command.Flags {
+		if slices.Contains(f.Names(), "format") {
+			if sf, ok := f.(*cli.StringFlag); ok {
+				formatFlag = sf
+			}
+		}
+	}
+
+	require.NotNil(t, formatFlag, "format flag should exist")
+
+	for _, valid := range OutputFormats {
+		assert.NoError(t, formatFlag.Validator(valid), "format %q should be valid", valid)
+	}
+
+	assert.Error(t, formatFlag.Validator("invalid"), "invalid format should fail validation")
+	assert.Error(t, formatFlag.Validator(""), "empty format should fail validation")
+}
+
+func TestCommandSuggestEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, Command.Suggest, "root command should have Suggest enabled")
+
+	for _, cmd := range Command.Commands {
+		if !cmd.Hidden {
+			assert.True(t, cmd.Suggest, "subcommand %s should have Suggest enabled", cmd.Name)
+		}
+	}
+}
+
+func TestSubcommandCategories(t *testing.T) {
+	t.Parallel()
+
+	for _, cmd := range Command.Commands {
+		if !cmd.Hidden && cmd.Category != "" {
+			assert.Equal(t, "API RESOURCE", cmd.Category, "subcommand %s has unexpected category", cmd.Name)
+		}
+	}
+}
+
+func TestOutputFormats(t *testing.T) {
+	t.Parallel()
+
+	expected := []string{"auto", "explore", "json", "jsonl", "pretty", "raw", "yaml"}
+	assert.Equal(t, expected, OutputFormats)
+}
+
+func TestSmokeHelpOutput(t *testing.T) {
+	t.Parallel()
+
+	// Run the command with --help; it should not error
+	err := Command.Run(context.Background(), []string{"courier", "--help"})
+	assert.NoError(t, err)
+}
+
+func TestSmokeVersion(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, strings.HasPrefix(Version, "3."), "version should start with 3.")
+	assert.NotEmpty(t, Version)
+}
+
+func TestEachResourceHasSubcommands(t *testing.T) {
+	t.Parallel()
+
+	for _, cmd := range Command.Commands {
+		if cmd.Hidden {
+			continue
+		}
+
+		t.Run(cmd.Name, func(t *testing.T) {
+			assert.Greater(t, len(cmd.Commands), 0, "resource %s should have subcommands", cmd.Name)
+
+			for _, sub := range cmd.Commands {
+				assert.NotEmpty(t, sub.Name, "subcommand under %s should have a name", cmd.Name)
+				assert.NotNil(t, sub.Action, "subcommand %s/%s should have an action", cmd.Name, sub.Name)
+			}
+		})
+	}
+}

--- a/pkg/cmd/cmdutil_format_test.go
+++ b/pkg/cmd/cmdutil_format_test.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestFormatJSON_JSONFormat(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"name":"Alice","age":30}`)
+	result, err := formatJSON(os.Stdout, "test", data, "json", "")
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "name")
+	assert.Contains(t, string(result), "Alice")
+	assert.Contains(t, string(result), "age")
+	assert.Contains(t, string(result), "30")
+}
+
+func TestFormatJSON_JSONLFormat(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"name":"Alice","age":30}`)
+	// Use a non-terminal writer to avoid colors
+	r, w, _ := os.Pipe()
+	defer r.Close()
+	defer w.Close()
+
+	result, err := formatJSON(w, "test", data, "jsonl", "")
+	require.NoError(t, err)
+
+	output := string(result)
+	assert.True(t, strings.HasSuffix(output, "\n"), "jsonl output should end with newline")
+	// jsonl should be one line (no extra newlines except the trailing one)
+	lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
+	assert.Len(t, lines, 1, "jsonl should be a single line")
+	assert.Contains(t, output, "name")
+	assert.Contains(t, output, "Alice")
+}
+
+func TestFormatJSON_RawFormat(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"name":"Alice"}`)
+	result, err := formatJSON(os.Stdout, "test", data, "raw", "")
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"Alice"}`+"\n", string(result))
+}
+
+func TestFormatJSON_PrettyFormat(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"name":"Alice"}`)
+	result, err := formatJSON(os.Stdout, "test", data, "pretty", "")
+	require.NoError(t, err)
+	output := string(result)
+	assert.Contains(t, output, "name:")
+	assert.Contains(t, output, "Alice")
+}
+
+func TestFormatJSON_YAMLFormat(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"name":"Alice","age":30}`)
+	r, w, _ := os.Pipe()
+	defer r.Close()
+
+	_, err := formatJSON(w, "test", data, "yaml", "")
+	w.Close()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+	assert.Contains(t, output, "name:")
+	assert.Contains(t, output, "Alice")
+	assert.Contains(t, output, "age:")
+}
+
+func TestFormatJSON_AutoFormat(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"key":"value"}`)
+	resultAuto, err := formatJSON(os.Stdout, "test", data, "auto", "")
+	require.NoError(t, err)
+	resultJSON, err := formatJSON(os.Stdout, "test", data, "json", "")
+	require.NoError(t, err)
+	assert.Equal(t, resultJSON, resultAuto, "auto should produce same output as json")
+}
+
+func TestFormatJSON_InvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"key":"value"}`)
+	_, err := formatJSON(os.Stdout, "test", data, "nonexistent", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid format")
+}
+
+func TestFormatJSON_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"key":"value"}`)
+	result1, err := formatJSON(os.Stdout, "test", data, "JSON", "")
+	require.NoError(t, err)
+	result2, err := formatJSON(os.Stdout, "test", data, "json", "")
+	require.NoError(t, err)
+	assert.Equal(t, result1, result2)
+}
+
+func TestFormatJSON_Transform(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"user":{"name":"Alice"},"count":5}`)
+
+	t.Run("jsonl format applies transform", func(t *testing.T) {
+		r, w, _ := os.Pipe()
+		defer r.Close()
+		result, err := formatJSON(w, "test", data, "jsonl", "user.name")
+		require.NoError(t, err)
+		assert.Equal(t, "\"Alice\"\n", string(result))
+	})
+
+	t.Run("raw format skips transform", func(t *testing.T) {
+		result, err := formatJSON(os.Stdout, "test", data, "raw", "user.name")
+		require.NoError(t, err)
+		// raw format explicitly skips transform, so full data is returned
+		assert.Contains(t, string(result), "user")
+		assert.Contains(t, string(result), "count")
+	})
+
+	t.Run("non-existent transform keeps original", func(t *testing.T) {
+		r, w, _ := os.Pipe()
+		defer r.Close()
+		result, err := formatJSON(w, "test", data, "jsonl", "nonexistent")
+		require.NoError(t, err)
+		// When transform target doesn't exist, original data is used
+		assert.Contains(t, string(result), "user")
+	})
+}
+
+func TestShowJSON_Transform(t *testing.T) {
+	t.Parallel()
+
+	data := gjson.Parse(`{"outer":{"inner":"deep"}}`)
+
+	t.Run("raw format skips transform", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "showjson-raw-*")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+		defer tmpFile.Close()
+
+		err = ShowJSON(tmpFile, "test", data, "raw", "outer.inner")
+		require.NoError(t, err)
+
+		tmpFile.Seek(0, 0)
+		content, err := os.ReadFile(tmpFile.Name())
+		require.NoError(t, err)
+		// raw format explicitly skips transforms
+		assert.Contains(t, string(content), "outer")
+	})
+
+	t.Run("jsonl format applies transform", func(t *testing.T) {
+		r, w, _ := os.Pipe()
+		defer r.Close()
+
+		err := ShowJSON(w, "test", data, "jsonl", "outer.inner")
+		w.Close()
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		buf.ReadFrom(r)
+		assert.Equal(t, "\"deep\"\n", buf.String(), "transform should extract nested value")
+	})
+}
+
+func TestCountTerminalLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		data     string
+		width    int
+		expected int
+	}{
+		{"empty", "", 80, 0},
+		{"single line", "hello", 80, 0},
+		{"two lines", "line1\nline2", 80, 1},
+		{"wrapped at width boundary", strings.Repeat("x", 160), 80, 1},
+		{"multiple newlines", "a\nb\nc\nd", 80, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := countTerminalLines([]byte(tt.data), tt.width)
+			assert.Equal(t, tt.expected, lines)
+		})
+	}
+}
+
+func TestShouldUseColors(t *testing.T) {
+	t.Run("FORCE_COLOR=1", func(t *testing.T) {
+		t.Setenv("FORCE_COLOR", "1")
+		assert.True(t, shouldUseColors(os.Stdout))
+	})
+
+	t.Run("FORCE_COLOR=0", func(t *testing.T) {
+		t.Setenv("FORCE_COLOR", "0")
+		assert.False(t, shouldUseColors(os.Stdout))
+	})
+
+	t.Run("non-terminal writer", func(t *testing.T) {
+		t.Setenv("FORCE_COLOR", "")
+		os.Unsetenv("FORCE_COLOR")
+		var buf bytes.Buffer
+		assert.False(t, shouldUseColors(&buf))
+	})
+}
+
+func TestIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pipe is not terminal", func(t *testing.T) {
+		r, w, _ := os.Pipe()
+		defer r.Close()
+		defer w.Close()
+		assert.False(t, isTerminal(w))
+	})
+
+	t.Run("bytes buffer is not terminal", func(t *testing.T) {
+		var buf bytes.Buffer
+		assert.False(t, isTerminal(&buf))
+	})
+}

--- a/pkg/cmd/cmdutil_iterator_test.go
+++ b/pkg/cmd/cmdutil_iterator_test.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rawJSONItem implements HasRawJSON for testing
+type rawJSONItem struct {
+	raw string
+}
+
+func (r rawJSONItem) RawJSON() string { return r.raw }
+
+// testIterator is a simple in-memory iterator for testing
+type testIterator[T any] struct {
+	items   []T
+	index   int
+	current T
+	err     error
+}
+
+func newTestIterator[T any](items ...T) *testIterator[T] {
+	return &testIterator[T]{items: items, index: -1}
+}
+
+func (it *testIterator[T]) Next() bool {
+	it.index++
+	if it.index >= len(it.items) {
+		return false
+	}
+	it.current = it.items[it.index]
+	return true
+}
+
+func (it *testIterator[T]) Current() T { return it.current }
+func (it *testIterator[T]) Err() error { return it.err }
+
+func TestShowJSONIterator_Formats(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		format   string
+		items    []rawJSONItem
+		contains []string
+		usePipe  bool // yaml writes directly to the writer, not via returned bytes
+	}{
+		{
+			name:     "raw",
+			format:   "raw",
+			items:    []rawJSONItem{{`{"id":"1","name":"alpha"}`}, {`{"id":"2","name":"beta"}`}},
+			contains: []string{`{"id":"1","name":"alpha"}`, `{"id":"2","name":"beta"}`},
+		},
+		{
+			name:     "jsonl",
+			format:   "jsonl",
+			items:    []rawJSONItem{{`{"id":"1"}`}, {`{"id":"2"}`}, {`{"id":"3"}`}},
+			contains: []string{`{"id":"1"}`, `{"id":"2"}`, `{"id":"3"}`},
+		},
+		{
+			name:     "json",
+			format:   "json",
+			items:    []rawJSONItem{{`{"status":"ok"}`}},
+			contains: []string{"status", "ok"},
+		},
+		{
+			name:     "pretty",
+			format:   "pretty",
+			items:    []rawJSONItem{{`{"name":"Alice","age":30}`}},
+			contains: []string{"name:", "Alice"},
+		},
+		{
+			name:     "yaml",
+			format:   "yaml",
+			items:    []rawJSONItem{{`{"name":"Alice","age":30}`}},
+			contains: []string{"name:", "Alice"},
+			usePipe:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			iter := newTestIterator(tt.items...)
+
+			var output string
+			if tt.usePipe {
+				r, w, err := os.Pipe()
+				require.NoError(t, err)
+				defer r.Close()
+				err = ShowJSONIterator(w, "Test", iter, tt.format, "")
+				w.Close()
+				require.NoError(t, err)
+				buf := make([]byte, 8192)
+				n, _ := r.Read(buf)
+				output = string(buf[:n])
+			} else {
+				tmpFile, err := os.CreateTemp("", "iter-*")
+				require.NoError(t, err)
+				defer os.Remove(tmpFile.Name())
+				defer tmpFile.Close()
+				err = ShowJSONIterator(tmpFile, "Test", iter, tt.format, "")
+				require.NoError(t, err)
+				tmpFile.Seek(0, 0)
+				content, err := os.ReadFile(tmpFile.Name())
+				require.NoError(t, err)
+				output = string(content)
+			}
+
+			for _, s := range tt.contains {
+				assert.Contains(t, output, s)
+			}
+		})
+	}
+}
+
+func TestShowJSONIterator_EmptyIterator(t *testing.T) {
+	t.Parallel()
+
+	items := newTestIterator[rawJSONItem]()
+
+	tmpFile, err := os.CreateTemp("", "iter-empty-*")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	err = ShowJSONIterator(tmpFile, "Test", items, "json", "")
+	require.NoError(t, err)
+
+	tmpFile.Seek(0, 0)
+	content, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+	assert.Empty(t, string(content), "empty iterator should produce no output")
+}
+
+func TestShowJSONIterator_WithTransform(t *testing.T) {
+	t.Parallel()
+
+	items := newTestIterator(
+		rawJSONItem{`{"data":{"value":"deep"},"other":"skip"}`},
+	)
+
+	tmpFile, err := os.CreateTemp("", "iter-transform-*")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	err = ShowJSONIterator(tmpFile, "Test", items, "jsonl", "data.value")
+	require.NoError(t, err)
+
+	tmpFile.Seek(0, 0)
+	content, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+
+	output := string(content)
+	assert.Equal(t, "\"deep\"\n", output, "transform should extract nested value")
+}
+
+func TestShowJSONIterator_NonRawJSONItem(t *testing.T) {
+	t.Parallel()
+
+	type plainItem struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	items := newTestIterator(
+		plainItem{ID: "1", Name: "alpha"},
+		plainItem{ID: "2", Name: "beta"},
+	)
+
+	tmpFile, err := os.CreateTemp("", "iter-plain-*")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	err = ShowJSONIterator(tmpFile, "Test", items, "raw", "")
+	require.NoError(t, err)
+
+	tmpFile.Seek(0, 0)
+	content, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+
+	output := string(content)
+	assert.Contains(t, output, "alpha")
+	assert.Contains(t, output, "beta")
+}
+
+func TestShowJSONIterator_IteratorError(t *testing.T) {
+	t.Parallel()
+
+	items := newTestIterator(
+		rawJSONItem{`{"id":"1"}`},
+	)
+	items.err = assert.AnError
+
+	tmpFile, err := os.CreateTemp("", "iter-err-*")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	err = ShowJSONIterator(tmpFile, "Test", items, "raw", "")
+	// After iterating all items, iter.Err() should be returned
+	assert.Error(t, err)
+}

--- a/pkg/cmd/cmdutil_test.go
+++ b/pkg/cmd/cmdutil_test.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"bytes"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -12,116 +10,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStreamOutput(t *testing.T) {
-	t.Setenv("PAGER", "cat")
-	err := streamOutput("stream test", func(w *os.File) error {
-		_, writeErr := w.WriteString("Hello world\n")
-		return writeErr
-	})
-	if err != nil {
-		t.Errorf("streamOutput failed: %v", err)
-	}
-}
-
-func TestWriteBinaryResponse(t *testing.T) {
-	t.Run("write to explicit file", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		outfile := tmpDir + "/output.txt"
-		body := []byte("test content")
-		resp := &http.Response{
-			Body: io.NopCloser(bytes.NewReader(body)),
-		}
-
-		msg, err := writeBinaryResponse(resp, outfile)
-
-		require.NoError(t, err)
-		assert.Contains(t, msg, outfile)
-
-		content, err := os.ReadFile(outfile)
-		require.NoError(t, err)
-		assert.Equal(t, body, content)
-	})
-
-	t.Run("write to stdout", func(t *testing.T) {
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		body := []byte("stdout content")
-		resp := &http.Response{
-			Body: io.NopCloser(bytes.NewReader(body)),
-		}
-		msg, err := writeBinaryResponse(resp, "-")
-
-		w.Close()
-		os.Stdout = oldStdout
-
-		require.NoError(t, err)
-		assert.Empty(t, msg)
-
-		var buf bytes.Buffer
-		_, _ = buf.ReadFrom(r)
-		assert.Equal(t, body, buf.Bytes())
-	})
-}
-
 func TestCreateDownloadFile(t *testing.T) {
-	t.Run("creates file with filename from header", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		oldWd, _ := os.Getwd()
-		os.Chdir(tmpDir)
-		defer os.Chdir(oldWd)
+	t.Parallel()
 
-		resp := &http.Response{
-			Header: http.Header{
-				"Content-Disposition": []string{`attachment; filename="test.txt"`},
-			},
-		}
-		file, err := createDownloadFile(resp, []byte("test content"))
-		require.NoError(t, err)
-		defer file.Close()
-		assert.Equal(t, "test.txt", filepath.Base(file.Name()))
-
-		// Create a second file with the same name to ensure it doesn't clobber the first
-		resp2 := &http.Response{
-			Header: http.Header{
-				"Content-Disposition": []string{`attachment; filename="test.txt"`},
-			},
-		}
-		file2, err := createDownloadFile(resp2, []byte("second content"))
-		require.NoError(t, err)
-		defer file2.Close()
-		assert.NotEqual(t, file.Name(), file2.Name(), "second file should have a different name")
-		assert.Contains(t, filepath.Base(file2.Name()), "test")
-	})
-
-	t.Run("creates temp file when no header", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		oldWd, _ := os.Getwd()
-		os.Chdir(tmpDir)
-		defer os.Chdir(oldWd)
+	t.Run("uses Content-Disposition filename", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		origDir, _ := os.Getwd()
+		require.NoError(t, os.Chdir(dir))
+		defer os.Chdir(origDir)
 
 		resp := &http.Response{Header: http.Header{}}
-		file, err := createDownloadFile(resp, []byte("test content"))
+		resp.Header.Set("Content-Disposition", `attachment; filename="report.csv"`)
+
+		f, err := createDownloadFile(resp, []byte("a,b,c"))
 		require.NoError(t, err)
-		defer file.Close()
-		assert.Contains(t, filepath.Base(file.Name()), "file-")
+		defer f.Close()
+		defer os.Remove(f.Name())
+		assert.Equal(t, "report.csv", filepath.Base(f.Name()))
 	})
 
-	t.Run("prevents directory traversal", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		oldWd, _ := os.Getwd()
-		os.Chdir(tmpDir)
-		defer os.Chdir(oldWd)
+	t.Run("falls back to MIME sniffing when no Content-Disposition", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		origDir, _ := os.Getwd()
+		require.NoError(t, os.Chdir(dir))
+		defer os.Chdir(origDir)
 
-		resp := &http.Response{
-			Header: http.Header{
-				"Content-Disposition": []string{`attachment; filename="../../../etc/passwd"`},
-			},
-		}
-		file, err := createDownloadFile(resp, []byte("test content"))
+		resp := &http.Response{Header: http.Header{}}
+		pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+		f, err := createDownloadFile(resp, pngData)
 		require.NoError(t, err)
-		defer file.Close()
-		assert.Equal(t, "passwd", filepath.Base(file.Name()))
+		defer f.Close()
+		defer os.Remove(f.Name())
+		assert.Contains(t, f.Name(), ".png")
+	})
+
+	t.Run("directory traversal in filename is sanitized", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		origDir, _ := os.Getwd()
+		require.NoError(t, os.Chdir(dir))
+		defer os.Chdir(origDir)
+
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("Content-Disposition", `attachment; filename="../../../etc/passwd"`)
+
+		f, err := createDownloadFile(resp, []byte("not really"))
+		require.NoError(t, err)
+		defer f.Close()
+		defer os.Remove(f.Name())
+		assert.Equal(t, "passwd", filepath.Base(f.Name()))
 	})
 }

--- a/pkg/cmd/error_paths_test.go
+++ b/pkg/cmd/error_paths_test.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cliProject(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "cmd", "...")
+}
+
+func runCLIExpectError(t *testing.T, flags ...string) string {
+	t.Helper()
+	project := cliProject(t)
+	args := []string{"run", project}
+	args = append(args, flags...)
+	cmd := exec.Command("go", args...)
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	assert.Error(t, err, "expected CLI to return an error")
+	return out.String()
+}
+
+// ---------------------------------------------------------------------------
+// Missing required flags
+// ---------------------------------------------------------------------------
+
+func TestError_MissingRequiredFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		command     string
+		subcommand  string
+		expectedMsg string
+	}{
+		{"audience", "audiences", "retrieve", "audience-id"},
+		{"brand", "brands", "retrieve", "brand-id"},
+		{"list", "lists", "retrieve", "list-id"},
+		{"message", "messages", "retrieve", "message-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output := runCLIExpectError(t,
+				tt.command, tt.subcommand,
+				"--api-key", "test-key",
+				"--format", "raw",
+			)
+			assert.Contains(t, output, tt.expectedMsg)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Invalid format flag
+// ---------------------------------------------------------------------------
+
+func TestError_InvalidFormat(t *testing.T) {
+	t.Parallel()
+	output := runCLIExpectError(t,
+		"--format", "invalid-format",
+		"brands", "list",
+		"--api-key", "test-key",
+	)
+	assert.Contains(t, output, "invalid-format")
+}
+
+// ---------------------------------------------------------------------------
+// Extra unexpected arguments
+// ---------------------------------------------------------------------------
+
+func TestError_ExtraArguments(t *testing.T) {
+	t.Parallel()
+	output := runCLIExpectError(t,
+		"audiences", "retrieve",
+		"--api-key", "test-key",
+		"--audience-id", "test-id",
+		"--format", "raw",
+		"--base-url", "http://localhost:1",
+		"extra-arg-1", "extra-arg-2",
+	)
+	assert.Contains(t, output, "Unexpected extra arguments")
+}
+
+// ---------------------------------------------------------------------------
+// API error simulation with httptest
+// ---------------------------------------------------------------------------
+
+func TestError_API404(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message":"not found","type":"error"}`)
+	}))
+	defer srv.Close()
+
+	output := runCLIExpectError(t,
+		"brands", "retrieve",
+		"--brand-id", "nonexistent",
+		"--api-key", "test-key",
+		"--base-url", srv.URL,
+		"--format", "raw",
+	)
+	assert.Contains(t, output, "not found")
+}
+
+func TestError_API401(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"message":"unauthorized","type":"error"}`)
+	}))
+	defer srv.Close()
+
+	output := runCLIExpectError(t,
+		"brands", "list",
+		"--api-key", "bad-key",
+		"--base-url", srv.URL,
+		"--format", "raw",
+	)
+	assert.Contains(t, output, "unauthorized")
+}
+
+func TestError_API500(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"message":"internal server error","type":"error"}`)
+	}))
+	defer srv.Close()
+
+	output := runCLIExpectError(t,
+		"audiences", "list",
+		"--api-key", "test-key",
+		"--base-url", srv.URL,
+		"--format", "raw",
+	)
+	assert.Contains(t, output, "internal server error")
+}
+
+func TestError_ConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	output := runCLIExpectError(t,
+		"brands", "list",
+		"--api-key", "test-key",
+		"--base-url", "http://localhost:1",
+		"--format", "raw",
+	)
+	assert.NotEmpty(t, output, "connection refused should produce error output")
+}
+
+// ---------------------------------------------------------------------------
+// Unknown subcommand
+// ---------------------------------------------------------------------------
+
+func TestError_UnknownSubcommand(t *testing.T) {
+	t.Parallel()
+
+	project := cliProject(t)
+	args := []string{"run", project, "nonexistent-command"}
+
+	cmd := exec.Command("go", args...)
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	assert.Error(t, err)
+	output := out.String()
+	assert.True(t,
+		strings.Contains(output, "not found") || strings.Contains(output, "Did you mean"),
+		"unknown command should mention 'not found' or suggest alternatives: %s", output,
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Help flag doesn't error
+// ---------------------------------------------------------------------------
+
+func TestNoError_HelpFlag(t *testing.T) {
+	t.Parallel()
+	err := Command.Run(context.Background(), []string{"courier", "brands", "--help"})
+	assert.NoError(t, err)
+}
+
+func TestNoError_SubcommandHelp(t *testing.T) {
+	t.Parallel()
+	err := Command.Run(context.Background(), []string{"courier", "audiences", "retrieve", "--help"})
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// API error with format-error flag
+// ---------------------------------------------------------------------------
+
+func TestError_FormatErrorFlag(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"message":"bad request","type":"invalid_request_error"}`)
+	}))
+	defer srv.Close()
+
+	output := runCLIExpectError(t,
+		"brands", "list",
+		"--api-key", "test-key",
+		"--base-url", srv.URL,
+		"--format", "raw",
+		"--format-error", "raw",
+	)
+	assert.Contains(t, output, "bad request")
+}

--- a/pkg/cmd/flagoptions_func_test.go
+++ b/pkg/cmd/flagoptions_func_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trycourier/courier-cli/internal/apiquery"
+	"github.com/trycourier/courier-cli/internal/requestflag"
+	"github.com/urfave/cli/v3"
+)
+
+func TestFlagOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		flags      []cli.Flag
+		setFlags   map[string]string
+		bodyType   BodyContentType
+		stdinInUse bool
+		wantEmpty  bool
+	}{
+		{
+			name:      "empty body, no flags",
+			flags:     []cli.Flag{},
+			bodyType:  EmptyBody,
+			wantEmpty: true,
+		},
+		{
+			name:     "query flag produces options",
+			flags:    []cli.Flag{&requestflag.Flag[string]{Name: "cursor", QueryPath: "cursor"}},
+			setFlags: map[string]string{"cursor": "abc123"},
+			bodyType: EmptyBody,
+		},
+		{
+			name:     "header flag produces options",
+			flags:    []cli.Flag{&requestflag.Flag[string]{Name: "idempotency-key", HeaderPath: "Idempotency-Key"}},
+			setFlags: map[string]string{"idempotency-key": "unique-key-123"},
+			bodyType: EmptyBody,
+		},
+		{
+			name:     "application/json body",
+			flags:    []cli.Flag{&requestflag.Flag[string]{Name: "name", BodyPath: "name"}},
+			setFlags: map[string]string{"name": "test-name"},
+			bodyType: ApplicationJSON,
+		},
+		{
+			name:     "application/octet-stream with string body",
+			flags:    []cli.Flag{&requestflag.Flag[string]{Name: "data", BodyRoot: true}},
+			setFlags: map[string]string{"data": "raw-binary-content"},
+			bodyType: ApplicationOctetStream,
+		},
+		{
+			name:     "debug mode adds middleware",
+			flags:    []cli.Flag{&cli.BoolFlag{Name: "debug"}},
+			setFlags: map[string]string{"debug": "true"},
+			bodyType: EmptyBody,
+		},
+		{
+			name:     "multipart form encoded",
+			flags:    []cli.Flag{&requestflag.Flag[string]{Name: "field", BodyPath: "field"}},
+			setFlags: map[string]string{"field": "value"},
+			bodyType: MultipartFormEncoded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cli.Command{Name: "test", Flags: tt.flags}
+			for k, v := range tt.setFlags {
+				cmd.Set(k, v)
+			}
+			opts, err := flagOptions(cmd, apiquery.NestedQueryFormatBrackets, apiquery.ArrayQueryFormatComma, tt.bodyType, tt.stdinInUse)
+			require.NoError(t, err)
+			if tt.wantEmpty {
+				assert.Empty(t, opts)
+			} else {
+				assert.NotEmpty(t, opts)
+			}
+		})
+	}
+}
+
+func TestGuessExtension(t *testing.T) {
+	t.Parallel()
+
+	t.Run("JPEG", func(t *testing.T) {
+		data := []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46}
+		assert.Equal(t, ".jpg", guessExtension(data))
+	})
+
+	t.Run("PNG", func(t *testing.T) {
+		data := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+		assert.Equal(t, ".png", guessExtension(data))
+	})
+
+	t.Run("GIF", func(t *testing.T) {
+		data := []byte("GIF89a" + "\x00\x00\x00\x00")
+		assert.Equal(t, ".gif", guessExtension(data))
+	})
+
+	t.Run("PDF", func(t *testing.T) {
+		data := []byte("%PDF-1.4 test content here")
+		assert.Equal(t, ".pdf", guessExtension(data))
+	})
+
+	t.Run("ZIP", func(t *testing.T) {
+		data := []byte{0x50, 0x4B, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00}
+		assert.Equal(t, ".zip", guessExtension(data))
+	})
+
+	t.Run("plain text returns a text extension", func(t *testing.T) {
+		data := []byte("Hello, World! This is plain text.")
+		ext := guessExtension(data)
+		assert.NotEmpty(t, ext)
+		// text/plain may return .asc or .txt depending on the platform
+		assert.True(t, ext == ".txt" || ext == ".asc", "expected .txt or .asc, got %s", ext)
+	})
+
+	t.Run("HTML returns an HTML extension", func(t *testing.T) {
+		data := []byte("<html><body>Hello</body></html>")
+		ext := guessExtension(data)
+		assert.True(t, ext == ".html" || ext == ".htm", "expected .html or .htm, got %s", ext)
+	})
+
+	t.Run("JSON returns a text extension", func(t *testing.T) {
+		data := []byte(`{"key":"value"}`)
+		ext := guessExtension(data)
+		assert.NotEmpty(t, ext)
+	})
+}
+
+func TestGuessExtension_Binary(t *testing.T) {
+	t.Parallel()
+
+	// Random binary data that doesn't match known signatures
+	data := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	ext := guessExtension(data)
+	assert.NotEmpty(t, ext, "should return some extension for unknown binary")
+}
+

--- a/pkg/cmd/inbound_test.go
+++ b/pkg/cmd/inbound_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestInboundTrackEvent(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"inbound", "track-event",

--- a/pkg/cmd/integration_test.go
+++ b/pkg/cmd/integration_test.go
@@ -1,0 +1,304 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func apiKey(t *testing.T) string {
+	t.Helper()
+	key := os.Getenv("COURIER_API_KEY")
+	if key == "" {
+		t.Skip("COURIER_API_KEY not set; skipping integration test")
+	}
+	return key
+}
+
+func runCLI(t *testing.T, flags ...string) string {
+	t.Helper()
+	key := apiKey(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok, "Could not get caller file path")
+	project := filepath.Join(filepath.Dir(filename), "..", "..", "cmd", "...")
+
+	args := []string{"run", project, "--format", "raw"}
+	args = append(args, flags...)
+
+	hasKey := false
+	for _, f := range flags {
+		if f == "--api-key" {
+			hasKey = true
+			break
+		}
+	}
+	if !hasKey {
+		args = append(args, "--api-key", key)
+	}
+
+	t.Logf("courier %s", strings.Join(args[4:], " "))
+
+	cmd := exec.Command("go", args...)
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	require.NoError(t, err, "CLI command failed:\n%s", out.String())
+	return out.String()
+}
+
+// ---------------------------------------------------------------------------
+// Read-only list operations (safe against any workspace)
+// ---------------------------------------------------------------------------
+
+func TestIntegration_BrandsList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	output := runCLI(t, "brands", "list")
+	assert.Contains(t, output, "{")
+}
+
+func TestIntegration_MessagesList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	output := runCLI(t, "messages", "list")
+	assert.Contains(t, output, "{")
+}
+
+func TestIntegration_AudiencesList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	output := runCLI(t, "audiences", "list")
+	assert.Contains(t, output, "{")
+}
+
+func TestIntegration_NotificationsList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	output := runCLI(t, "notifications", "list")
+	assert.Contains(t, output, "{")
+}
+
+func TestIntegration_TenantsList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	output := runCLI(t, "tenants", "list")
+	assert.Contains(t, output, "{")
+}
+
+func TestIntegration_ListsList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	output := runCLI(t, "lists", "list")
+	assert.Contains(t, output, "{")
+}
+
+func TestIntegration_AuditEventsList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	output := runCLI(t, "audit-events", "list")
+	assert.Contains(t, output, "{")
+}
+
+// ---------------------------------------------------------------------------
+// Brand CRUD cycle: create → retrieve → update → delete
+// ---------------------------------------------------------------------------
+
+func TestIntegration_BrandCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	key := apiKey(t)
+	_ = key
+
+	brandID := fmt.Sprintf("cli-test-%d", time.Now().UnixMilli())
+	brandName := "CLI Integration Test Brand"
+
+	// Create (settings is required by the API)
+	out := runCLI(t, "brands", "create", "--name", brandName, "--id", brandID,
+		"--settings", `{colors: {primary: "#9D3789", secondary: "#9D3789"}}`)
+	assert.Contains(t, out, brandID)
+
+	// Retrieve
+	out = runCLI(t, "brands", "retrieve", "--brand-id", brandID)
+	assert.Contains(t, out, brandName)
+
+	// Update (settings also required on update)
+	updatedName := "CLI Integration Test Brand Updated"
+	out = runCLI(t, "brands", "update", "--brand-id", brandID, "--name", updatedName,
+		"--settings", `{colors: {primary: "#9D3789", secondary: "#9D3789"}}`)
+	assert.Contains(t, out, updatedName)
+
+	// Delete
+	runCLI(t, "brands", "delete", "--brand-id", brandID)
+}
+
+// ---------------------------------------------------------------------------
+// List (resource) CRUD cycle: update (upsert) → retrieve → delete
+// ---------------------------------------------------------------------------
+
+func TestIntegration_ListCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	listID := fmt.Sprintf("cli-test-%d", time.Now().UnixMilli())
+	listName := "CLI Integration Test List"
+
+	// Upsert
+	out := runCLI(t, "lists", "update", "--list-id", listID, "--name", listName)
+	_ = out
+
+	// Retrieve
+	out = runCLI(t, "lists", "retrieve", "--list-id", listID)
+	assert.Contains(t, out, listName)
+
+	// Delete
+	runCLI(t, "lists", "delete", "--list-id", listID)
+}
+
+// ---------------------------------------------------------------------------
+// Profile create/merge → retrieve
+// ---------------------------------------------------------------------------
+
+func TestIntegration_ProfileCreateAndRetrieve(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	userID := fmt.Sprintf("cli-test-user-%d", time.Now().UnixMilli())
+	profile := `{email: "test@example.com"}`
+
+	// Create/merge (profiles create uses --profile)
+	out := runCLI(t, "profiles", "create", "--user-id", userID, "--profile", profile)
+	_ = out
+
+	// Retrieve
+	out = runCLI(t, "profiles", "retrieve", "--user-id", userID)
+	assert.Contains(t, out, "test@example.com")
+
+	// Cleanup: delete
+	runCLI(t, "profiles", "delete", "--user-id", userID)
+}
+
+// ---------------------------------------------------------------------------
+// Send a message (enqueues even without configured channels)
+// ---------------------------------------------------------------------------
+
+func TestIntegration_SendMessage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	userID := fmt.Sprintf("cli-test-send-%d", time.Now().UnixMilli())
+	msg := fmt.Sprintf(`{to: {user_id: %q}, content: {title: "Test", body: "Integration test message"}}`, userID)
+
+	out := runCLI(t, "send", "message", "--message", msg)
+	assert.Contains(t, out, "requestId")
+}
+
+// ---------------------------------------------------------------------------
+// Auth: issue token
+// ---------------------------------------------------------------------------
+
+func TestIntegration_AuthIssueToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	userID := fmt.Sprintf("cli-test-auth-%d", time.Now().UnixMilli())
+
+	out := runCLI(t, "auth", "issue-token",
+		"--scope", fmt.Sprintf("user_id:%s read:preferences", userID),
+		"--expires-in", "1 day",
+	)
+	assert.Contains(t, out, "token")
+}
+
+// ---------------------------------------------------------------------------
+// Error path: retrieve nonexistent resource should fail
+// ---------------------------------------------------------------------------
+
+func TestIntegration_RetrieveNonexistentBrand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	key := apiKey(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	project := filepath.Join(filepath.Dir(filename), "..", "..", "cmd", "...")
+
+	cmd := exec.Command("go", "run", project, "--format", "raw",
+		"brands", "retrieve",
+		"--brand-id", "nonexistent-brand-id-xyz-12345",
+		"--api-key", key,
+	)
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	assert.Error(t, err, "retrieving a nonexistent brand should return an error")
+}
+
+// ---------------------------------------------------------------------------
+// Tenant CRUD cycle: update (upsert) → retrieve → delete
+// ---------------------------------------------------------------------------
+
+func TestIntegration_TenantCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tenantID := fmt.Sprintf("cli-test-tenant-%d", time.Now().UnixMilli())
+	tenantName := "CLI Integration Test Tenant"
+
+	// Create/upsert
+	out := runCLI(t, "tenants", "update", "--tenant-id", tenantID, "--name", tenantName)
+	_ = out
+
+	// Retrieve
+	out = runCLI(t, "tenants", "retrieve", "--tenant-id", tenantID)
+	assert.Contains(t, out, tenantName)
+
+	// Delete
+	runCLI(t, "tenants", "delete", "--tenant-id", tenantID)
+}
+
+func TestIntegration_RetrieveNonexistentList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	key := apiKey(t)
+
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	project := filepath.Join(filepath.Dir(filename), "..", "..", "cmd", "...")
+
+	cmd := exec.Command("go", "run", project, "--format", "raw",
+		"lists", "retrieve",
+		"--list-id", "nonexistent-list-id-xyz-12345",
+		"--api-key", key,
+	)
+	var out strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	assert.Error(t, err, "retrieving a nonexistent list should return an error")
+}

--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestListsRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists", "retrieve",
@@ -20,7 +19,6 @@ func TestListsRetrieve(t *testing.T) {
 }
 
 func TestListsUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists", "update",
@@ -45,7 +43,6 @@ func TestListsUpdate(t *testing.T) {
 }
 
 func TestListsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists", "list",
@@ -56,7 +53,6 @@ func TestListsList(t *testing.T) {
 }
 
 func TestListsDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists", "delete",
@@ -66,7 +62,6 @@ func TestListsDelete(t *testing.T) {
 }
 
 func TestListsRestore(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists", "restore",

--- a/pkg/cmd/listsubscription_test.go
+++ b/pkg/cmd/listsubscription_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestListsSubscriptionsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists:subscriptions", "list",
@@ -21,7 +20,6 @@ func TestListsSubscriptionsList(t *testing.T) {
 }
 
 func TestListsSubscriptionsAdd(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists:subscriptions", "add",
@@ -44,7 +42,6 @@ func TestListsSubscriptionsAdd(t *testing.T) {
 }
 
 func TestListsSubscriptionsSubscribe(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists:subscriptions", "subscribe",
@@ -67,7 +64,6 @@ func TestListsSubscriptionsSubscribe(t *testing.T) {
 }
 
 func TestListsSubscriptionsSubscribeUser(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists:subscriptions", "subscribe-user",
@@ -92,7 +88,6 @@ func TestListsSubscriptionsSubscribeUser(t *testing.T) {
 }
 
 func TestListsSubscriptionsUnsubscribeUser(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"lists:subscriptions", "unsubscribe-user",

--- a/pkg/cmd/message_test.go
+++ b/pkg/cmd/message_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestMessagesRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"messages", "retrieve",
@@ -19,7 +18,6 @@ func TestMessagesRetrieve(t *testing.T) {
 }
 
 func TestMessagesList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"messages", "list",
@@ -42,7 +40,6 @@ func TestMessagesList(t *testing.T) {
 }
 
 func TestMessagesCancel(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"messages", "cancel",
@@ -52,7 +49,6 @@ func TestMessagesCancel(t *testing.T) {
 }
 
 func TestMessagesContent(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"messages", "content",
@@ -62,7 +58,6 @@ func TestMessagesContent(t *testing.T) {
 }
 
 func TestMessagesHistory(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"messages", "history",

--- a/pkg/cmd/notification_test.go
+++ b/pkg/cmd/notification_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestNotificationsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"notifications", "list",
@@ -20,7 +19,6 @@ func TestNotificationsList(t *testing.T) {
 }
 
 func TestNotificationsRetrieveContent(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"notifications", "retrieve-content",

--- a/pkg/cmd/notificationcheck_test.go
+++ b/pkg/cmd/notificationcheck_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestNotificationsChecksUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"notifications:checks", "update",
@@ -36,7 +35,6 @@ func TestNotificationsChecksUpdate(t *testing.T) {
 }
 
 func TestNotificationsChecksList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"notifications:checks", "list",
@@ -47,7 +45,6 @@ func TestNotificationsChecksList(t *testing.T) {
 }
 
 func TestNotificationsChecksDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"notifications:checks", "delete",

--- a/pkg/cmd/notificationdraft_test.go
+++ b/pkg/cmd/notificationdraft_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestNotificationsDraftRetrieveContent(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"notifications:draft", "retrieve-content",

--- a/pkg/cmd/profile_test.go
+++ b/pkg/cmd/profile_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestProfilesCreate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles", "create",
@@ -21,7 +20,6 @@ func TestProfilesCreate(t *testing.T) {
 }
 
 func TestProfilesRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles", "retrieve",
@@ -31,7 +29,6 @@ func TestProfilesRetrieve(t *testing.T) {
 }
 
 func TestProfilesUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles", "update",
@@ -55,7 +52,6 @@ func TestProfilesUpdate(t *testing.T) {
 }
 
 func TestProfilesDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles", "delete",
@@ -65,7 +61,6 @@ func TestProfilesDelete(t *testing.T) {
 }
 
 func TestProfilesReplace(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles", "replace",

--- a/pkg/cmd/profilelist_test.go
+++ b/pkg/cmd/profilelist_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestProfilesListsRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles:lists", "retrieve",
@@ -21,7 +20,6 @@ func TestProfilesListsRetrieve(t *testing.T) {
 }
 
 func TestProfilesListsDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles:lists", "delete",
@@ -31,7 +29,6 @@ func TestProfilesListsDelete(t *testing.T) {
 }
 
 func TestProfilesListsSubscribe(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"profiles:lists", "subscribe",

--- a/pkg/cmd/request_test.go
+++ b/pkg/cmd/request_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestRequestsArchive(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"requests", "archive",

--- a/pkg/cmd/send_test.go
+++ b/pkg/cmd/send_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestSendMessage(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"send", "message",

--- a/pkg/cmd/stdin_pipe_test.go
+++ b/pkg/cmd/stdin_pipe_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trycourier/courier-cli/internal/apiquery"
+	"github.com/trycourier/courier-cli/internal/requestflag"
+	"github.com/urfave/cli/v3"
+)
+
+// pipeStdin replaces os.Stdin with a pipe, writes data to it, and closes the
+// write end so the reader sees EOF. Returns a cleanup function that restores
+// the original stdin.
+func pipeStdin(t *testing.T, data string) func() {
+	t.Helper()
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdin = r
+	_, err = w.WriteString(data)
+	require.NoError(t, err)
+	w.Close()
+	return func() { os.Stdin = origStdin; r.Close() }
+}
+
+func TestFlagOptions_StdinJSON(t *testing.T) {
+	cleanup := pipeStdin(t, `{"name": "from-stdin", "color": "blue"}`)
+	defer cleanup()
+
+	cmd := &cli.Command{
+		Name: "test",
+		Flags: []cli.Flag{
+			&requestflag.Flag[string]{
+				Name:     "color",
+				BodyPath: "color",
+			},
+		},
+	}
+	// Flag not explicitly set; stdin provides both values
+	opts, err := flagOptions(cmd, apiquery.NestedQueryFormatBrackets, apiquery.ArrayQueryFormatComma, ApplicationJSON, false)
+	require.NoError(t, err)
+	assert.NotEmpty(t, opts, "piped JSON should produce request options")
+}
+
+func TestFlagOptions_StdinYAML(t *testing.T) {
+	cleanup := pipeStdin(t, "name: from-yaml\ncount: 3\n")
+	defer cleanup()
+
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{},
+	}
+
+	opts, err := flagOptions(cmd, apiquery.NestedQueryFormatBrackets, apiquery.ArrayQueryFormatComma, ApplicationJSON, false)
+	require.NoError(t, err)
+	assert.NotEmpty(t, opts, "piped YAML should produce request options")
+}
+
+func TestFlagOptions_StdinMergesWithFlags(t *testing.T) {
+	cleanup := pipeStdin(t, `{"name": "from-stdin"}`)
+	defer cleanup()
+
+	colorFlag := &requestflag.Flag[string]{
+		Name:     "color",
+		BodyPath: "color",
+	}
+
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{colorFlag},
+	}
+	cmd.Set("color", "red")
+
+	opts, err := flagOptions(cmd, apiquery.NestedQueryFormatBrackets, apiquery.ArrayQueryFormatComma, ApplicationJSON, false)
+	require.NoError(t, err)
+	assert.NotEmpty(t, opts, "merged stdin+flags should produce request options")
+}
+
+func TestFlagOptions_StdinSkippedWhenInUse(t *testing.T) {
+	cleanup := pipeStdin(t, `{"name": "should-be-ignored"}`)
+	defer cleanup()
+
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{},
+	}
+
+	opts, err := flagOptions(cmd, apiquery.NestedQueryFormatBrackets, apiquery.ArrayQueryFormatComma, EmptyBody, true)
+	require.NoError(t, err)
+	// stdinInUse=true, so stdin data is not read; no body options produced
+	assert.Empty(t, opts, "stdin should be ignored when stdinInUse is true")
+}
+
+func TestFlagOptions_StdinNonMapWithBodyFlags(t *testing.T) {
+	cleanup := pipeStdin(t, `[1, 2, 3]`)
+	defer cleanup()
+
+	bodyFlag := &requestflag.Flag[string]{
+		Name:     "name",
+		BodyPath: "name",
+	}
+
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{bodyFlag},
+	}
+	cmd.Set("name", "test-name")
+
+	_, err := flagOptions(cmd, apiquery.NestedQueryFormatBrackets, apiquery.ArrayQueryFormatComma, ApplicationJSON, false)
+	assert.Error(t, err, "merging flags with a non-map stdin body should fail")
+	assert.Contains(t, err.Error(), "Cannot merge flags with a body that is not a map")
+}
+
+func TestFlagOptions_StdinEmpty(t *testing.T) {
+	cleanup := pipeStdin(t, "")
+	defer cleanup()
+
+	cmd := &cli.Command{
+		Name:  "test",
+		Flags: []cli.Flag{},
+	}
+
+	opts, err := flagOptions(cmd, apiquery.NestedQueryFormatBrackets, apiquery.ArrayQueryFormatComma, EmptyBody, false)
+	require.NoError(t, err)
+	assert.Empty(t, opts, "empty stdin should produce no options")
+}

--- a/pkg/cmd/suggest_test.go
+++ b/pkg/cmd/suggest_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v3"
+)
+
+func TestJaroDistance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		a, b     string
+		expected float64
+	}{
+		{"", "", 1.0},
+		{"", "abc", 0.0},
+		{"abc", "", 0.0},
+		{"abc", "abc", 1.0},
+		{"martha", "marhta", 0.9444444444444444},
+		{"kitten", "sitting", 0.746031746031746},
+		{"a", "a", 1.0},
+		{"a", "b", 0.0},
+		{"ab", "ba", 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			result := jaroDistance(tt.a, tt.b)
+			assert.InDelta(t, tt.expected, result, 0.0001, "jaroDistance(%q, %q)", tt.a, tt.b)
+		})
+	}
+}
+
+func TestJaroDistanceSymmetry(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{
+		{"hello", "hallo"},
+		{"abc", "xyz"},
+		{"test", "tent"},
+	}
+
+	for _, pair := range pairs {
+		t.Run(pair[0]+"_"+pair[1], func(t *testing.T) {
+			assert.Equal(t, jaroDistance(pair[0], pair[1]), jaroDistance(pair[1], pair[0]))
+		})
+	}
+}
+
+func TestJaroWinkler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		a, b string
+		// jaroWinkler should always be >= jaroDistance for strings with common prefix
+		expectHigherThanJaro bool
+	}{
+		{"martha", "marhta", true},
+		{"dwayne", "duane", true},
+		{"abc", "xyz", false},
+		{"test", "test", false}, // identical strings; jaro already 1.0
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			jw := jaroWinkler(tt.a, tt.b)
+			jd := jaroDistance(tt.a, tt.b)
+			assert.GreaterOrEqual(t, jw, jd, "jaroWinkler should be >= jaroDistance")
+			if tt.expectHigherThanJaro && jd > 0.7 {
+				assert.Greater(t, jw, jd, "jaroWinkler should boost score for common prefix above threshold")
+			}
+		})
+	}
+}
+
+func TestSuggestCommand(t *testing.T) {
+	t.Parallel()
+
+	commands := []*cli.Command{
+		{Name: "retrieve"},
+		{Name: "update"},
+		{Name: "list"},
+		{Name: "delete"},
+	}
+
+	tests := []struct {
+		provided string
+		contains string
+	}{
+		{"retrive", "retrieve"},
+		{"retirev", "retrieve"},
+		{"updat", "update"},
+		{"delet", "delete"},
+		{"lst", "list"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provided, func(t *testing.T) {
+			result := suggestCommand(commands, tt.provided)
+			assert.Contains(t, result, tt.contains)
+			assert.Contains(t, result, "Did you mean")
+		})
+	}
+}
+
+func TestSuggestCommandWithAliases(t *testing.T) {
+	t.Parallel()
+
+	commands := []*cli.Command{
+		{Name: "generate", Aliases: []string{"gen", "g"}},
+		{Name: "test"},
+	}
+
+	result := suggestCommand(commands, "generaet")
+	assert.Contains(t, result, "Did you mean")
+}
+
+func TestSuggestCommand_NoCloseMatch(t *testing.T) {
+	t.Parallel()
+
+	commands := []*cli.Command{
+		{Name: "retrieve"},
+		{Name: "update"},
+		{Name: "list"},
+		{Name: "delete"},
+	}
+
+	// "xyzzy" has no meaningful similarity to any command; suggestCommand
+	// still returns a "Did you mean" with whichever name scores highest,
+	// even if the score is very low.
+	result := suggestCommand(commands, "xyzzy")
+	assert.Contains(t, result, "Did you mean")
+}

--- a/pkg/cmd/tenant_test.go
+++ b/pkg/cmd/tenant_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestTenantsRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants", "retrieve",
@@ -20,7 +19,6 @@ func TestTenantsRetrieve(t *testing.T) {
 }
 
 func TestTenantsUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants", "update",
@@ -52,7 +50,6 @@ func TestTenantsUpdate(t *testing.T) {
 }
 
 func TestTenantsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants", "list",
@@ -64,7 +61,6 @@ func TestTenantsList(t *testing.T) {
 }
 
 func TestTenantsDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants", "delete",
@@ -74,7 +70,6 @@ func TestTenantsDelete(t *testing.T) {
 }
 
 func TestTenantsListUsers(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants", "list-users",

--- a/pkg/cmd/tenantpreferenceitem_test.go
+++ b/pkg/cmd/tenantpreferenceitem_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestTenantsPreferencesItemsUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants:preferences:items", "update",
@@ -23,7 +22,6 @@ func TestTenantsPreferencesItemsUpdate(t *testing.T) {
 }
 
 func TestTenantsPreferencesItemsDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants:preferences:items", "delete",

--- a/pkg/cmd/tenanttemplate_test.go
+++ b/pkg/cmd/tenanttemplate_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestTenantsTemplatesRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants:templates", "retrieve",
@@ -21,7 +20,6 @@ func TestTenantsTemplatesRetrieve(t *testing.T) {
 }
 
 func TestTenantsTemplatesList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants:templates", "list",
@@ -33,7 +31,6 @@ func TestTenantsTemplatesList(t *testing.T) {
 }
 
 func TestTenantsTemplatesPublish(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants:templates", "publish",
@@ -45,7 +42,6 @@ func TestTenantsTemplatesPublish(t *testing.T) {
 }
 
 func TestTenantsTemplatesReplace(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants:templates", "replace",

--- a/pkg/cmd/tenanttemplateversion_test.go
+++ b/pkg/cmd/tenanttemplateversion_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestTenantsTemplatesVersionsRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"tenants:templates:versions", "retrieve",

--- a/pkg/cmd/translation_test.go
+++ b/pkg/cmd/translation_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestTranslationsRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"translations", "retrieve",
@@ -20,7 +19,6 @@ func TestTranslationsRetrieve(t *testing.T) {
 }
 
 func TestTranslationsUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"translations", "update",

--- a/pkg/cmd/userpreference_test.go
+++ b/pkg/cmd/userpreference_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestUsersPreferencesRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:preferences", "retrieve",
@@ -21,7 +20,6 @@ func TestUsersPreferencesRetrieve(t *testing.T) {
 }
 
 func TestUsersPreferencesRetrieveTopic(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:preferences", "retrieve-topic",
@@ -33,7 +31,6 @@ func TestUsersPreferencesRetrieveTopic(t *testing.T) {
 }
 
 func TestUsersPreferencesUpdateOrCreateTopic(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:preferences", "update-or-create-topic",

--- a/pkg/cmd/usertenant_test.go
+++ b/pkg/cmd/usertenant_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestUsersTenantsList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tenants", "list",
@@ -22,7 +21,6 @@ func TestUsersTenantsList(t *testing.T) {
 }
 
 func TestUsersTenantsAddMultiple(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tenants", "add-multiple",
@@ -47,7 +45,6 @@ func TestUsersTenantsAddMultiple(t *testing.T) {
 }
 
 func TestUsersTenantsAddSingle(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tenants", "add-single",
@@ -59,7 +56,6 @@ func TestUsersTenantsAddSingle(t *testing.T) {
 }
 
 func TestUsersTenantsRemoveAll(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tenants", "remove-all",
@@ -69,7 +65,6 @@ func TestUsersTenantsRemoveAll(t *testing.T) {
 }
 
 func TestUsersTenantsRemoveSingle(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tenants", "remove-single",

--- a/pkg/cmd/usertoken_test.go
+++ b/pkg/cmd/usertoken_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestUsersTokensRetrieve(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tokens", "retrieve",
@@ -21,7 +20,6 @@ func TestUsersTokensRetrieve(t *testing.T) {
 }
 
 func TestUsersTokensUpdate(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tokens", "update",
@@ -47,7 +45,6 @@ func TestUsersTokensUpdate(t *testing.T) {
 }
 
 func TestUsersTokensList(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tokens", "list",
@@ -57,7 +54,6 @@ func TestUsersTokensList(t *testing.T) {
 }
 
 func TestUsersTokensDelete(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tokens", "delete",
@@ -68,7 +64,6 @@ func TestUsersTokensDelete(t *testing.T) {
 }
 
 func TestUsersTokensAddMultiple(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tokens", "add-multiple",
@@ -78,7 +73,6 @@ func TestUsersTokensAddMultiple(t *testing.T) {
 }
 
 func TestUsersTokensAddSingle(t *testing.T) {
-	t.Skip("Mock server tests are disabled")
 	mocktest.TestRunMockTestWithFlags(
 		t,
 		"users:tokens", "add-single",


### PR DESCRIPTION
## Summary

- **Remove redundant tests** superseded by table-driven equivalents (13 individual staticdisplay type tests, `JaroWinklerKnownValues`, `SubcommandsHaveActions`, `ShowJSON_WritesToFile`, duplicate iterator transform test)
- **Convert to table-driven tests** across 5 test groups: `formatResult` types, `flagOptions` variants, missing-required-flag errors, iterator format outputs, and hidden subcommands
- **Tighten weak assertions**: `countTerminalLines` now uses exact expected values instead of `GreaterOrEqual`; vacuous `NotContains` in `ShowJSON_Transform` replaced with exact `Equal`
- **Fill coverage gaps**: `createDownloadFile` (Content-Disposition, MIME fallback, directory traversal sanitization), no-close-match suggest, tenant CRUD integration test
- **Un-skip 26 auto-generated mock server tests** by updating the `mocktest` helper to gracefully skip when the mock server is unreachable instead of hard-failing
- **Add new test files**: stdin piping, error paths (missing flags, invalid format, API errors via httptest, connection refused, unknown subcommands), command structure, format functions, iterator output, explorer/static display rendering, and real-API integration tests gated on `COURIER_API_KEY`