### PR TITLE
docs: add npm install method to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ It is generated with [Stainless](https://www.stainless.com/).
 
 ## Installation
 
+### Installing with npm
+
+```sh
+npm install -g @trycourier/cli
+```
+
+This downloads a platform-specific native binary via a postinstall step. No Node.js runtime is needed after installation.
+
 ### Installing with Homebrew
 
 ```sh


### PR DESCRIPTION
## Summary

- Adds npm as the first install option in the README (`npm install -g @trycourier/cli`), matching the docs page at courier.com/docs/tools/cli.
- npm was already the recommended cross-platform install method but was missing from the repo README.