### PR TITLE
chore: remove Homebrew distribution

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,6 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
   publish-npm:
     needs: goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,19 +78,3 @@ nfpms:
     contents:
       - src: man/man1/*.1.gz
         dst: /usr/share/man/man1/
-homebrew_casks:
-  - name: courier
-    repository:
-      owner: trycourier
-      name: homebrew-courier
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    homepage: https://courier.com
-    description: The official Courier CLI for managing notifications from the command line.
-    license: Apache-2.0
-    binary: "courier"
-    completions:
-      bash: "completions/courier.bash"
-      zsh: "completions/courier.zsh"
-      fish: "completions/courier.fish"
-    manpages:
-    - man/man1/courier.1.gz

--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ npm install -g @trycourier/cli
 
 This downloads a platform-specific native binary via a postinstall step. No Node.js runtime is needed after installation.
 
-### Installing with Homebrew
-
-```sh
-brew install trycourier/courier/courier
-```
-
 ### Installing with Go
 
 To test or install the CLI locally, you need [Go](https://go.dev/doc/install) version 1.22 or later installed.

--- a/npm/README.md
+++ b/npm/README.md
@@ -10,7 +10,6 @@ npm install -g @trycourier/cli
 
 ### Other install methods
 
-- **Homebrew**: `brew install trycourier/courier/courier`
 - **Go**: `go install github.com/trycourier/courier-cli/cmd/courier@latest`
 - **Binary**: [GitHub Releases](https://github.com/trycourier/courier-cli/releases)
 


### PR DESCRIPTION
## Summary

- Remove `homebrew_casks` block from `.goreleaser.yml` so future releases don't publish a Homebrew cask
- Remove `HOMEBREW_TAP_GITHUB_TOKEN` env var from the publish-release workflow
- Remove Homebrew install instructions from `README.md` and `npm/README.md`

Homebrew cask is blocked by macOS Gatekeeper on unsigned binaries; npm and direct download remain as install methods.