### PR TITLE
chore: remove go install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,6 @@ npm install -g @trycourier/cli
 
 This downloads a platform-specific native binary via a postinstall step. No Node.js runtime is needed after installation.
 
-### Installing with Go
-
-To test or install the CLI locally, you need [Go](https://go.dev/doc/install) version 1.22 or later installed.
-
-```sh
-go install 'github.com/trycourier/courier-cli/cmd/courier@latest'
-```
-
-Once you have run `go install`, the binary is placed in your Go bin directory:
-
-- **Default location**: `$HOME/go/bin` (or `$GOPATH/bin` if GOPATH is set)
-- **Check your path**: Run `go env GOPATH` to see the base directory
-
-If commands aren't found after installation, add the Go bin directory to your PATH:
-
-```sh
-# Add to your shell profile (.zshrc, .bashrc, etc.)
-export PATH="$PATH:$(go env GOPATH)/bin"
-```
-
 <!-- x-release-please-end -->
 
 ### Running Locally

--- a/npm/README.md
+++ b/npm/README.md
@@ -10,7 +10,6 @@ npm install -g @trycourier/cli
 
 ### Other install methods
 
-- **Go**: `go install github.com/trycourier/courier-cli/cmd/courier@latest`
 - **Binary**: [GitHub Releases](https://github.com/trycourier/courier-cli/releases)
 
 ## Usage


### PR DESCRIPTION
go install is broken due to module versioning (legacy v2.7.2 tag + missing /v3 suffix). npm and direct download remain.